### PR TITLE
Add parameter rawcontinue to fix API breakage

### DIFF
--- a/fbot/lib/core/Revision.java
+++ b/fbot/lib/core/Revision.java
@@ -4,7 +4,6 @@
 package fbot.lib.core;
 
 import fbot.lib.core.auxi.JSONParse;
-import java.io.PrintStream;
 import java.util.ArrayList;
 import org.json.JSONArray;
 import org.json.JSONObject;

--- a/fbot/lib/core/URLBuilder.java
+++ b/fbot/lib/core/URLBuilder.java
@@ -26,7 +26,7 @@ public class URLBuilder {
 
     public void setDomain(String domain) {
         this.domain = domain;
-        this.base = String.format("https://%s/w/api.php?format=json&action=", domain);
+        this.base = String.format("https://%s/w/api.php?rawcontinue=&format=json&action=", domain);
     }
 
     /**
@@ -86,7 +86,7 @@ public class URLBuilder {
         this.clearAction();
     }
 
-    public static /* varargs */ String chainParams(String ... params) {
+    public static String chainParams(String ... params) {
         if (params.length % 2 == 1) {
             throw new UnsupportedOperationException("params contains an odd number of elements:" + params.length);
         }
@@ -97,7 +97,7 @@ public class URLBuilder {
         return x;
     }
 
-    public static /* varargs */ String chainProps(String ... props) {
+    public static String chainProps(String ... props) {
         String x = "";
         if (props.length >= 1) {
             x = String.valueOf(x) + props[0];


### PR DESCRIPTION
This fixes: https://lists.wikimedia.org/pipermail/mediawiki-api/2015-June/003582.html

Next steps:
- Bump version and update https://commons.wikimedia.org/wiki/Commons:GlobalReplace/MinimumVersion
- Update https://commons.wikimedia.org/wiki/Commons:GlobalReplace and announce to users they have to download the new version.
